### PR TITLE
Convert app to Chrome extension plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@ Unscramm is an interactive "animated spellcheck" that shows how a misspelled wor
 - Build: `npm run build`
 - Test (CI): `npm test`
 
+## Chrome Extension
+
+The app is packaged as a Manifest V3 Chrome extension with a simple popup UI.
+
+### Building the Extension
+
+```bash
+npm run build
+```
+
+This builds the extension to the `dist/` folder, including:
+- `manifest.json` - Chrome extension manifest
+- `index.html` - Popup UI
+- `assets/` - Bundled JS, CSS, and images
+- `icon*.svg` - Extension icons
+
+### Loading in Chrome
+
+1. Build the extension: `npm run build`
+2. Open Chrome and navigate to `chrome://extensions/`
+3. Enable "Developer mode" (toggle in top-right)
+4. Click "Load unpacked"
+5. Select the `dist/` folder
+6. The Unscramm extension icon will appear in your toolbar
+7. Click the icon to open the popup and use the app
+
 ## Design Tokens
 
 Source of truth: `src/index.css` under the `@theme` block. These CSS variables define colors, typography, and semantic states used across the app.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && npm run build:extension",
+    "build:extension": "cp public/manifest.json dist/ && cp public/icon*.svg dist/",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest --run",

--- a/public/icon128.svg
+++ b/public/icon128.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" fill="#8B5CF6"/>
+  <text x="64" y="90" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="white" text-anchor="middle">U</text>
+</svg>

--- a/public/icon16.svg
+++ b/public/icon16.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#8B5CF6"/>
+  <text x="8" y="12" font-family="Arial, sans-serif" font-size="10" font-weight="bold" fill="white" text-anchor="middle">U</text>
+</svg>

--- a/public/icon48.svg
+++ b/public/icon48.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <rect width="48" height="48" fill="#8B5CF6"/>
+  <text x="24" y="34" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">U</text>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "Unscramm",
+  "version": "0.0.1",
+  "description": "Visualize text transformations and spelling corrections",
+  "action": {
+    "default_popup": "index.html",
+    "default_title": "Unscramm"
+  },
+  "icons": {
+    "16": "icon16.svg",
+    "48": "icon48.svg",
+    "128": "icon128.svg"
+  },
+  "permissions": []
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
   };
 
   return (
-    <main className="main w-full max-w-[600px] mx-auto px-6 box-border">
+    <main className="main w-full max-w-[360px] mx-auto px-4 box-border">
       <h1 className="heading flex justify-center">
         <img src={logoUrl} alt="Unscramm" className="h-20" />
       </h1>
@@ -47,7 +47,7 @@ function App() {
         />
       </section>
 
-      <div className="panel input-panel flex items-center gap-2 w-full max-w-[600px] mt-6">
+      <div className="panel input-panel flex items-center gap-2 w-full max-w-[360px] mt-6">
         <input
           type="text"
           className="input flex-1"

--- a/src/components/DiffVisualizer.tsx
+++ b/src/components/DiffVisualizer.tsx
@@ -361,8 +361,8 @@ export default function DiffVisualizer({
   const { phase, letters } = animationState;
 
   return (
-    <div className="w-full max-w-[600px] px-6 box-border">
-      <div className="flex w-full justify-center gap-[0.025em] text-white text-[2rem] select-none">
+    <div className="w-full max-w-[360px] px-4 box-border">
+      <div className="flex w-full justify-center gap-[0.025em] text-white text-[1.5rem] select-none">
         <AnimatePresence initial={false}>
           {letters.map((l) => (
             <motion.span

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,15 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: './',
+  build: {
+    outDir: 'dist',
+    rollupOptions: {
+      output: {
+        entryFileNames: 'assets/[name].js',
+        chunkFileNames: 'assets/[name].js',
+        assetFileNames: 'assets/[name].[ext]'
+      }
+    }
+  }
 })


### PR DESCRIPTION
- Add manifest.json with popup action configuration
- Create extension icons (16px, 48px, 128px) as SVG
- Configure Vite for extension build with relative paths
- Adjust UI width from 600px to 360px for popup layout
- Add build:extension script to copy manifest and icons to dist/
- Update README with Chrome extension build and loading instructions

Extension can be loaded unpacked from dist/ folder after running npm run build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Package the app as a Chrome MV3 popup extension, adjust UI for a 360px popup, and add build/config steps to output a loadable `dist/` bundle with manifest and icons.
> 
> - **Extension Packaging (MV3)**
>   - Add `public/manifest.json` with `action.default_popup` pointing to `index.html` and icons.
>   - Add SVG icons: `public/icon16.svg`, `public/icon48.svg`, `public/icon128.svg`.
> - **Build/Config**
>   - Update `package.json` scripts: `build` now runs `vite` then `build:extension` to copy `manifest.json` and icons into `dist/`.
>   - Configure Vite (`vite.config.ts`) with `base: './'` and deterministic asset filenames under `assets/` for extension loading.
> - **UI/Layout tweaks for popup**
>   - Reduce max width from `600px` to `360px` and padding from `px-6` to `px-4` in `src/App.tsx` and `src/components/DiffVisualizer.tsx`.
>   - Decrease letter size from `text-[2rem]` to `text-[1.5rem]` for the visualizer.
> - **Docs**
>   - Update `README.md` with build steps and Chrome "Load unpacked" instructions for loading from `dist/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7981556e7c7cdee097d470744ac4fc6c2f1fba6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->